### PR TITLE
feat: add vehicle CRUD API with seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "ev-rental-system-backend",
   "version": "1.0.0",
   "description": "Backend service for EV Rental System",
+  "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "node server.js"
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
   },
   "repository": {
     "type": "git",

--- a/src/config/mongodb.js
+++ b/src/config/mongodb.js
@@ -1,12 +1,25 @@
 import mongoose from "mongoose";
 
+let isConnected = false;
+
 export const connectDB = async () => {
+  if (isConnected) {
+    return;
+  }
+
+  const uri =
+    process.env.ATLAS_URI ||
+    process.env.MONGODB_URI ||
+    "mongodb://127.0.0.1:27017/ev-rental-system";
+
   try {
-    await mongoose.connect(process.env.ATLAS_URI);
+    mongoose.set("strictQuery", true);
+    await mongoose.connect(uri);
+    isConnected = true;
     console.log("MongoDB connected successfully");
   } catch (error) {
-    console.error("MongoDB connection failed:", error);
-    process.exit(1); // Exit process with failure
+    console.error("MongoDB connection failed:", error.message);
+    throw error;
   }
 };
 

--- a/src/controllers/vehicle.controller.js
+++ b/src/controllers/vehicle.controller.js
@@ -1,0 +1,70 @@
+import Vehicle from "../models/vehicle.model.js";
+
+export const listVehicles = async (req, res, next) => {
+  try {
+    const vehicles = await Vehicle.find().sort({ createdAt: -1 });
+    res.json({ data: vehicles });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getVehicle = async (req, res, next) => {
+  try {
+    const vehicle = await Vehicle.findById(req.params.id);
+    if (!vehicle) {
+      return res.status(404).json({ message: "Vehicle not found" });
+    }
+    res.json({ data: vehicle });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createVehicle = async (req, res, next) => {
+  try {
+    const payload = req.body;
+    const vehicle = await Vehicle.create(payload);
+    res.status(201).json({ data: vehicle });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateVehicle = async (req, res, next) => {
+  try {
+    const payload = req.body;
+    const vehicle = await Vehicle.findByIdAndUpdate(req.params.id, payload, {
+      new: true,
+      runValidators: true,
+    });
+
+    if (!vehicle) {
+      return res.status(404).json({ message: "Vehicle not found" });
+    }
+
+    res.json({ data: vehicle });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteVehicle = async (req, res, next) => {
+  try {
+    const vehicle = await Vehicle.findByIdAndDelete(req.params.id);
+    if (!vehicle) {
+      return res.status(404).json({ message: "Vehicle not found" });
+    }
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default {
+  listVehicles,
+  getVehicle,
+  createVehicle,
+  updateVehicle,
+  deleteVehicle,
+};

--- a/src/models/vehicle.model.js
+++ b/src/models/vehicle.model.js
@@ -1,0 +1,53 @@
+import mongoose from "mongoose";
+
+const vehicleSchema = new mongoose.Schema(
+  {
+    stationId: {
+      type: String,
+      default: null,
+      trim: true,
+    },
+    vin: {
+      type: String,
+      trim: true,
+      unique: true,
+      sparse: true,
+    },
+    model: {
+      type: String,
+      trim: true,
+      required: true,
+    },
+    plateNo: {
+      type: String,
+      trim: true,
+      unique: true,
+      sparse: true,
+    },
+    batteryPercent: {
+      type: Number,
+      min: 0,
+      max: 100,
+      default: 100,
+    },
+    status: {
+      type: String,
+      trim: true,
+      enum: ["available", "maintenance", "rented", "unavailable"],
+      default: "available",
+    },
+    odometer: {
+      type: Number,
+      min: 0,
+      default: 0,
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  }
+);
+
+export const Vehicle = mongoose.model("Vehicle", vehicleSchema);
+
+export default Vehicle;

--- a/src/routes/vehicle.routes.js
+++ b/src/routes/vehicle.routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import {
+  listVehicles,
+  getVehicle,
+  createVehicle,
+  updateVehicle,
+  deleteVehicle,
+} from "../controllers/vehicle.controller.js";
+
+const router = Router();
+
+router.get("/", listVehicles);
+router.get("/:id", getVehicle);
+router.post("/", createVehicle);
+router.put("/:id", updateVehicle);
+router.delete("/:id", deleteVehicle);
+
+export default router;

--- a/src/seed/vehicle.seed.js
+++ b/src/seed/vehicle.seed.js
@@ -1,0 +1,37 @@
+import Vehicle from "../models/vehicle.model.js";
+
+const DEFAULT_VEHICLES = [
+  {
+    vin: "EVR-2024-0001",
+    model: "Tesla Model 3",
+    plateNo: "51H-123.45",
+    batteryPercent: 85,
+    status: "available",
+    odometer: 12450,
+    stationId: "station-hcm-01",
+  },
+  {
+    vin: "EVR-2024-0002",
+    model: "Nissan Leaf",
+    plateNo: "59A-678.90",
+    batteryPercent: 60,
+    status: "maintenance",
+    odometer: 30210,
+    stationId: "station-hcm-02",
+  },
+];
+
+export const seedVehicles = async () => {
+  for (const vehicle of DEFAULT_VEHICLES) {
+    await Vehicle.findOneAndUpdate(
+      { vin: vehicle.vin },
+      vehicle,
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  }
+
+  const count = await Vehicle.estimatedDocumentCount();
+  console.log(`Vehicle seed complete. Total vehicles: ${count}`);
+};
+
+export default seedVehicles;

--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,43 @@
-import express from 'express';
+import express from "express";
+import dotenv from "dotenv";
+
+import connectDB from "./config/mongodb.js";
+import vehicleRoutes from "./routes/vehicle.routes.js";
+import { seedVehicles } from "./seed/vehicle.seed.js";
+
+dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.get('/', (req, res) => {
-  res.send('Hello World!');
+app.use(express.json());
+
+app.get("/", (req, res) => {
+  res.json({ message: "EV Rental System API" });
 });
 
-app.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`);
+app.use("/api/vehicles", vehicleRoutes);
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  if (err.name === "ValidationError") {
+    return res.status(400).json({ message: err.message });
+  }
+  res.status(500).json({ message: "Internal server error" });
 });
+
+const startServer = async () => {
+  try {
+    await connectDB();
+    await seedVehicles();
+
+    app.listen(PORT, () => {
+      console.log(`Server is running on http://localhost:${PORT}`);
+    });
+  } catch (error) {
+    console.error("Server start failed:", error.message);
+    process.exit(1);
+  }
+};
+
+startServer();


### PR DESCRIPTION
## Summary
- update the Express server bootstrap to load environment variables, connect to MongoDB, and register vehicle routes
- add the vehicle model, controller, routes, and seed data to support CRUD endpoints with two default records
- configure the project for ES module usage and improve development workflow with nodemon

## Testing
- npm run start *(fails locally without a MongoDB instance)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e710452c832faba96d37358215c0